### PR TITLE
Adds ability to find term based on URL parameters

### DIFF
--- a/src/main/java/com/google/sps/servlets/AddSchoolData.java
+++ b/src/main/java/com/google/sps/servlets/AddSchoolData.java
@@ -10,7 +10,6 @@ import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.Filter;
 import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
-import com.google.sps.data.GraphDataObject;
 import java.io.IOException;
 import java.util.List;
 import javax.servlet.annotation.WebServlet;
@@ -140,8 +139,6 @@ public class AddSchoolData extends HttpServlet {
     Entity newTerm = new Entity("Term", parent);
     newTerm.setProperty("term", term);
     newTerm.setProperty("professorKey", professor);
-    GraphDataObject bug = new GraphDataObject("bug", "bug");
-    newTerm.setProperty("bug", bug);
     return newTerm;
   }
 

--- a/src/main/java/com/google/sps/servlets/LiveCourseData.java
+++ b/src/main/java/com/google/sps/servlets/LiveCourseData.java
@@ -24,7 +24,6 @@ public class LiveCourseData extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    findData(db, request);
     response.setContentType("text/html; charset=UTF-8");
     response.setCharacterEncoding("UTF-8");
     response.sendRedirect("/AddSchoolData.html");

--- a/src/main/java/com/google/sps/servlets/LiveCourseData.java
+++ b/src/main/java/com/google/sps/servlets/LiveCourseData.java
@@ -1,0 +1,78 @@
+package com.google.sps.servlets;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.CompositeFilterOperator;
+import com.google.appengine.api.datastore.Query.Filter;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/term-live")
+public class LiveCourseData extends HttpServlet {
+  private DatastoreService db = DatastoreServiceFactory.getDatastoreService();
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    findData(db, request);
+    response.setContentType("text/html; charset=UTF-8");
+    response.setCharacterEncoding("UTF-8");
+    response.sendRedirect("/AddSchoolData.html");
+  }
+
+  public Entity findData(DatastoreService db, HttpServletRequest request) {
+    String schoolName = request.getParameter("school-name");
+    String courseName = request.getParameter("course-name");
+    String termName = request.getParameter("term");
+    String profName = request.getParameter("professor-name");
+    Long units = Long.parseLong(request.getParameter("units"));
+
+    Entity foundTerm = findTerm(db, schoolName, courseName, termName, units, profName);
+    return foundTerm;
+  }
+
+  private Entity findTerm(
+      DatastoreService db,
+      String schoolName,
+      String courseName,
+      String termName,
+      Long units,
+      String profName) {
+    Key schoolKey = findQueryMatch(db, "School", "school-name", schoolName).get(0).getKey();
+
+    List<Filter> filters = new ArrayList();
+    Filter courseFilter = new FilterPredicate("course-name", FilterOperator.EQUAL, courseName);
+    Filter unitFilter = new FilterPredicate("units", FilterOperator.EQUAL, units);
+    filters.add(courseFilter);
+    filters.add(unitFilter);
+
+    Query courseQuery =
+        new Query("Course").setAncestor(schoolKey).setFilter(CompositeFilterOperator.and(filters));
+    Key courseKey =
+        db.prepare(courseQuery).asList(FetchOptions.Builder.withDefaults()).get(0).getKey();
+
+    Filter termFilter = new FilterPredicate("term", FilterOperator.EQUAL, termName);
+    Query termQuery = new Query("Term").setAncestor(courseKey).setFilter(termFilter);
+    Entity foundTerm = db.prepare(termQuery).asList(FetchOptions.Builder.withDefaults()).get(0);
+
+    return foundTerm;
+  }
+
+  private List<Entity> findQueryMatch(
+      DatastoreService db, String entityType, String entityProperty, String propertyValue) {
+    Filter filter = new FilterPredicate(entityProperty, FilterOperator.EQUAL, propertyValue);
+    Query q = new Query(entityType).setFilter(filter);
+    List<Entity> result = db.prepare(q).asList(FetchOptions.Builder.withDefaults());
+    return result;
+  }
+}

--- a/src/main/java/com/google/sps/servlets/LiveCourseData.java
+++ b/src/main/java/com/google/sps/servlets/LiveCourseData.java
@@ -29,7 +29,7 @@ public class LiveCourseData extends HttpServlet {
     response.sendRedirect("/AddSchoolData.html");
   }
 
-  public Entity findData(DatastoreService db, HttpServletRequest request) {
+  public Entity getTerm(DatastoreService db, HttpServletRequest request) {
     String schoolName = request.getParameter("school-name");
     String courseName = request.getParameter("course-name");
     String termName = request.getParameter("term");

--- a/src/test/java/com/google/sps/servlets/LiveCourseDataTest.java
+++ b/src/test/java/com/google/sps/servlets/LiveCourseDataTest.java
@@ -99,10 +99,4 @@ public final class LiveCourseDataTest {
     List<Entity> result = db.prepare(q).asList(FetchOptions.Builder.withDefaults());
     return result;
   }
-
-  private List<Entity> findQueryMatch(DatastoreService db, String entityType) {
-    Query q = new Query(entityType);
-    List<Entity> result = db.prepare(q).asList(FetchOptions.Builder.withDefaults());
-    return result;
-  }
 }

--- a/src/test/java/com/google/sps/servlets/LiveCourseDataTest.java
+++ b/src/test/java/com/google/sps/servlets/LiveCourseDataTest.java
@@ -70,7 +70,7 @@ public final class LiveCourseDataTest {
     newSchoolObject.addSchoolData(db, request);
     newSchoolObject.addSchoolData(db, requestB);
     Key expectedParent = findQueryMatch(db, "Course", "course-name", "6.006").get(0).getKey();
-    Entity found = LiveData.findData(db, request);
+    Entity found = LiveData.getTerm(db, request);
 
     assertEquals(expectedParent, found.getParent());
     assertEquals(expectedTermName, found.getProperty("term"));

--- a/src/test/java/com/google/sps/servlets/LiveCourseDataTest.java
+++ b/src/test/java/com/google/sps/servlets/LiveCourseDataTest.java
@@ -63,7 +63,14 @@ public final class LiveCourseDataTest {
   @Test
   public void FindingExisitngTermEntity() {
     DatastoreService db = DatastoreServiceFactory.getDatastoreService();
-    request = createRequest(request, "MIT", "6.006", "Spring 2020", "12", "Jason Ku");
+    request =
+        createRequest(
+            request, /*schoolName*/
+            "MIT", /*courseName*/
+            "6.006", /*termName*/
+            "Spring 2020", /*units*/
+            "12", /*profName*/
+            "Jason Ku");
     requestB = createRequest(requestB, "MIT", "6.008", "Spring 2018", "6", "Srini");
     String expectedTermName = "Spring 2020";
 

--- a/src/test/java/com/google/sps/servlets/LiveCourseDataTest.java
+++ b/src/test/java/com/google/sps/servlets/LiveCourseDataTest.java
@@ -1,0 +1,108 @@
+// // Copyright 2019 Google LLC
+// //
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.Filter;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+public final class LiveCourseDataTest {
+  private static final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+
+  private AddSchoolData newSchoolObject;
+  private LiveCourseData LiveData;
+
+  @BeforeEach
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    helper.setUp();
+    newSchoolObject = new AddSchoolData();
+    LiveData = new LiveCourseData();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Mock HttpServletRequest request;
+  @Mock HttpServletRequest requestB;
+
+  @Test
+  public void FindingExisitngTermEntity() {
+    DatastoreService db = DatastoreServiceFactory.getDatastoreService();
+    request = createRequest(request, "MIT", "6.006", "Spring 2020", "12", "Jason Ku");
+    requestB = createRequest(requestB, "MIT", "6.008", "Spring 2018", "6", "Srini");
+    String expectedTermName = "Spring 2020";
+
+    newSchoolObject.addSchoolData(db, request);
+    newSchoolObject.addSchoolData(db, requestB);
+    Key expectedParent = findQueryMatch(db, "Course", "course-name", "6.006").get(0).getKey();
+    Entity found = LiveData.findData(db, request);
+
+    assertEquals(expectedParent, found.getParent());
+    assertEquals(expectedTermName, found.getProperty("term"));
+  }
+
+  private HttpServletRequest createRequest(
+      HttpServletRequest request,
+      String schoolName,
+      String courseName,
+      String termName,
+      String units,
+      String profName) {
+    request = Mockito.mock(HttpServletRequest.class);
+    when(request.getParameter("school-name")).thenReturn(schoolName);
+    when(request.getParameter("course-name")).thenReturn(courseName);
+    when(request.getParameter("term")).thenReturn(termName);
+    when(request.getParameter("units")).thenReturn(units);
+    when(request.getParameter("professor-name")).thenReturn(profName);
+    return request;
+  }
+
+  private List<Entity> findQueryMatch(
+      DatastoreService db, String entityType, String entityProperty, String propertyValue) {
+    Filter filter = new FilterPredicate(entityProperty, FilterOperator.EQUAL, propertyValue);
+    Query q = new Query(entityType).setFilter(filter);
+    List<Entity> result = db.prepare(q).asList(FetchOptions.Builder.withDefaults());
+    return result;
+  }
+
+  private List<Entity> findQueryMatch(DatastoreService db, String entityType) {
+    Query q = new Query(entityType);
+    List<Entity> result = db.prepare(q).asList(FetchOptions.Builder.withDefaults());
+    return result;
+  }
+}


### PR DESCRIPTION
Starting use of live data

Adds: New servlet that simply takes in URL parameters and finds the term entity the rating data needs to be pulled from, I also added one test cases to make sure this was being done properly. Will add more test for invalid URL's
