### PR TITLE
Adds yaml file for sorting on deployment

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1,0 +1,6 @@
+indexes:
+  - kind: "Term"
+    ancestor: yes
+    properties:
+      - name: "timeStamp"
+        direction: desc


### PR DESCRIPTION
In my PreviousTerms.java I have a Datastore query that stacks an inequality and and ancestor composite filters. Turns out that in order for this to work on deployment you need to add a custom index configuration because Datastore does not make one automatically for a complex search like this. 

https://cloud.google.com/datastore/docs/tools/indexconfig
https://cloud.google.com/datastore/docs/concepts/indexes


> Firestore in Datastore mode provides built-in, or automatic, indexes for queries of the following forms:
> 
> Kindless queries using only ancestor and key filters
> Queries using only ancestor and equality filters
> Queries using only inequality filters (which are limited to a single property)
> Queries using only ancestor filters, equality filters on properties, and inequality filters on keys
> Queries with no filters and only one sort order on a property, either ascending or descending



> For more complex queries, an application must define composite, or manual, indexes. Composite indexes are required for queries of the following form:
> 
> Queries with ancestor and inequality filters
> Queries with one or more inequality filters on a property and one or more equality filters on other properties
> Queries with a sort order on keys in descending order
> Queries with multiple sort orders
> Queries with one or more filters and one or more sort orders