### PR TITLE
Adding term key as parameter of function

### DIFF
--- a/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -4,6 +4,7 @@ import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
@@ -139,7 +140,8 @@ public class DataServlet extends HttpServlet {
         queryEntities(
             /* entityName */ "Rating",
             /* propertyName */ "reviewer-id",
-            /* propertyValue */ userId);
+            /* propertyValue */ userId,
+            KeyFactory.stringToKey(termKeyString));
 
     Entity termRatingEntity =
         termRatingQueryList.isEmpty()
@@ -170,11 +172,12 @@ public class DataServlet extends HttpServlet {
     return score;
   }
 
-  public List<Entity> queryEntities(String entityName, String propertyName, String propertyValue)
+  public List<Entity> queryEntities(
+      String entityName, String propertyName, String propertyValue, Key ancestorKey)
       throws IOException {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Filter filter = new FilterPredicate(propertyName, FilterOperator.EQUAL, propertyValue);
-    Query query = new Query(entityName).setFilter(filter);
+    Query query = new Query(entityName).setFilter(filter).setAncestor(ancestorKey);
     // This is initialized when authentication happens, so should not be empty.
     List<Entity> queryList = datastore.prepare(query).asList(FetchOptions.Builder.withDefaults());
     return queryList;

--- a/src/test/java/com/google/sps/servlets/DataServletTest.java
+++ b/src/test/java/com/google/sps/servlets/DataServletTest.java
@@ -72,7 +72,9 @@ public final class DataServletTest {
 
     AnalyzeSentimentResponse response =
         AnalyzeSentimentResponse.newBuilder()
-            .setDocumentSentiment(Sentiment.newBuilder().setScore((float) -0.8999999761581421)) // Sentiment Score of Text.
+            .setDocumentSentiment(
+                Sentiment.newBuilder()
+                    .setScore((float) -0.8999999761581421)) // Sentiment Score of Text.
             .build();
     when(languageService.analyzeSentiment(any(Document.class))).thenReturn(response);
 
@@ -92,7 +94,8 @@ public final class DataServletTest {
             .queryEntities(
                 /* entityName */ "Rating",
                 /* propertyName */ "reviewer-id",
-                /* propertyValue */ "9223372036854775807")
+                /* propertyValue */ "9223372036854775807",
+                KeyFactory.stringToKey(termKeyString))
             .get(0);
 
     // ASSERT.
@@ -120,7 +123,9 @@ public final class DataServletTest {
 
     AnalyzeSentimentResponse response =
         AnalyzeSentimentResponse.newBuilder()
-            .setDocumentSentiment(Sentiment.newBuilder().setScore((float) -0.699999988079071)) // Sentiment Score of Text.
+            .setDocumentSentiment(
+                Sentiment.newBuilder()
+                    .setScore((float) -0.699999988079071)) // Sentiment Score of Text.
             .build();
     when(languageService.analyzeSentiment(any(Document.class))).thenReturn(response);
 
@@ -149,7 +154,8 @@ public final class DataServletTest {
             .queryEntities(
                 /* entityName */ "Rating",
                 /* propertyName */ "reviewer-id",
-                /* propertyValue */ "9223372036854775807")
+                /* propertyValue */ "9223372036854775807",
+                KeyFactory.stringToKey(termKeyString))
             .get(0);
     // ASSERT.
     assertEquals("C", termRatingEntity.getProperty("grade"));


### PR DESCRIPTION
Found a bug that DataServlet was querying into all Rating Entities, when it should have been looking at Rating of a specific term. 

Added:
  - TermKey as a parameter of the queryEntities() in DataServlet
  - Added same as above for when the function is used in DataServletTest